### PR TITLE
Add Netlify plugin for Next.js and update dependencies

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,6 @@
 
 [build.environment]
   NODE_VERSION = "20"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "nextjs",
-  "version": "4.0.0",
+  "name": "tonuxcorp",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nextjs",
-      "version": "4.0.0",
+      "name": "tonuxcorp",
+      "version": "5.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@vercel/analytics": "^1.6.1",
@@ -24,6 +24,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@netlify/plugin-nextjs": "^5.15.8",
         "@tailwindcss/typography": "^0.5.19",
         "@types/node": "^25.3.5",
         "@types/react": "^19.2.14",
@@ -153,6 +154,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@netlify/plugin-nextjs": {
+      "version": "5.15.8",
+      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.15.8.tgz",
+      "integrity": "sha512-zxHVtYhNV1ixLX/4xX6PFTxpM5ltfQIMXUo0JbppUWvDaYeeZIqoEmlYdfIHx6BKyjLSMm8D/b3IRReK5VYuyA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -2694,6 +2705,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "@netlify/plugin-nextjs": {
+      "version": "5.15.8",
+      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.15.8.tgz",
+      "integrity": "sha512-zxHVtYhNV1ixLX/4xX6PFTxpM5ltfQIMXUo0JbppUWvDaYeeZIqoEmlYdfIHx6BKyjLSMm8D/b3IRReK5VYuyA==",
+      "dev": true
     },
     "@next/env": {
       "version": "14.2.35",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "deploy": "npx vercel --prod"
   },
   "devDependencies": {
+    "@netlify/plugin-nextjs": "^5.15.8",
     "@tailwindcss/typography": "^0.5.19",
     "@types/node": "^25.3.5",
     "@types/react": "^19.2.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,6 +87,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@netlify/plugin-nextjs@^5.15.8":
+  version "5.15.8"
+  resolved "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.15.8.tgz"
+  integrity sha512-zxHVtYhNV1ixLX/4xX6PFTxpM5ltfQIMXUo0JbppUWvDaYeeZIqoEmlYdfIHx6BKyjLSMm8D/b3IRReK5VYuyA==
+
 "@next/env@^13.4.3":
   version "13.5.11"
   resolved "https://registry.npmjs.org/@next/env/-/env-13.5.11.tgz"
@@ -429,6 +434,11 @@ framer-motion@^12.35.1:
     motion-dom "^12.35.1"
     motion-utils "^12.29.2"
     tslib "^2.4.0"
+
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Summary by Sourcery

Configure Netlify for the Next.js app and align dependencies with the new deployment setup.

New Features:
- Add the official Netlify Next.js plugin to the project configuration.

Build:
- Configure Netlify to use the Next.js plugin in netlify.toml and set Node.js 20 for builds.

Chores:
- Add the Netlify Next.js plugin as a development dependency and update lockfiles accordingly.