### PR TITLE
Update portfolio: fix Jengu/Jangflix stacks to Flutter and add new pr…

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -155,8 +155,8 @@
       {
         "title": "Sembass",
         "description": "Jengu application - digital platform",
-        "type": "web",
-        "techs": ["React", "Node.js", "MongoDB"],
+        "type": "mobile",
+        "techs": ["Flutter", "Firebase"],
         "url": "http://sembass.com"
       },
       {
@@ -170,7 +170,7 @@
         "title": "Jangflix",
         "description": "Educational mobile app with interactive courses, quizzes and badge system",
         "type": "mobile",
-        "techs": ["React Native", "Node.js", "Firebase"],
+        "techs": ["Flutter", "Node.js", "Firebase"],
         "url": "https://jangflix.com"
       },
       {
@@ -186,6 +186,48 @@
         "type": "web",
         "techs": ["Next.js", "PWA", "Tailwind CSS"],
         "url": "http://wirdmaaxuuz.com"
+      },
+      {
+        "title": "RNP",
+        "description": "RNP mobile application",
+        "type": "mobile",
+        "techs": ["Flutter", "Firebase", "Directus", "PostgreSQL"],
+        "url": ""
+      },
+      {
+        "title": "DepuisleChamp",
+        "description": "DepuisleChamp web platform",
+        "type": "web",
+        "techs": ["Next.js", "Directus", "Umami"],
+        "url": ""
+      },
+      {
+        "title": "Forum Mondial de l'Eau",
+        "description": "Mobile application for the World Water Forum",
+        "type": "mobile",
+        "techs": ["Flutter"],
+        "url": ""
+      },
+      {
+        "title": "OIF x Gebeya",
+        "description": "Web platform for OIF in collaboration with Gebeya",
+        "type": "web",
+        "techs": ["Angular", "Spring Boot"],
+        "url": ""
+      },
+      {
+        "title": "IPRES",
+        "description": "Web platform for IPRES",
+        "type": "web",
+        "techs": ["Ruby on Rails"],
+        "url": ""
+      },
+      {
+        "title": "TekkiFi",
+        "description": "TekkiFi mobile application",
+        "type": "mobile",
+        "techs": ["Flutter"],
+        "url": ""
       }
     ]
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -155,8 +155,8 @@
       {
         "title": "Sembass",
         "description": "Application Jengu - plateforme digitale",
-        "type": "web",
-        "techs": ["React", "Node.js", "MongoDB"],
+        "type": "mobile",
+        "techs": ["Flutter", "Firebase"],
         "url": "http://sembass.com"
       },
       {
@@ -170,7 +170,7 @@
         "title": "Jangflix",
         "description": "Application mobile educative avec cours interactifs, quiz et systeme de badges",
         "type": "mobile",
-        "techs": ["React Native", "Node.js", "Firebase"],
+        "techs": ["Flutter", "Node.js", "Firebase"],
         "url": "https://jangflix.com"
       },
       {
@@ -186,6 +186,48 @@
         "type": "web",
         "techs": ["Next.js", "PWA", "Tailwind CSS"],
         "url": "http://wirdmaaxuuz.com"
+      },
+      {
+        "title": "RNP",
+        "description": "Application mobile RNP",
+        "type": "mobile",
+        "techs": ["Flutter", "Firebase", "Directus", "PostgreSQL"],
+        "url": ""
+      },
+      {
+        "title": "DepuisleChamp",
+        "description": "Plateforme web DepuisleChamp",
+        "type": "web",
+        "techs": ["Next.js", "Directus", "Umami"],
+        "url": ""
+      },
+      {
+        "title": "Forum Mondial de l'Eau",
+        "description": "Application mobile pour le Forum Mondial de l'Eau",
+        "type": "mobile",
+        "techs": ["Flutter"],
+        "url": ""
+      },
+      {
+        "title": "OIF x Gebeya",
+        "description": "Plateforme web pour l'OIF en collaboration avec Gebeya",
+        "type": "web",
+        "techs": ["Angular", "Spring Boot"],
+        "url": ""
+      },
+      {
+        "title": "IPRES",
+        "description": "Plateforme web pour l'IPRES",
+        "type": "web",
+        "techs": ["Ruby on Rails"],
+        "url": ""
+      },
+      {
+        "title": "TekkiFi",
+        "description": "Application mobile TekkiFi",
+        "type": "mobile",
+        "techs": ["Flutter"],
+        "url": ""
       }
     ]
   },


### PR DESCRIPTION
…ojects

- Sembass/Jengu: React → Flutter, type web → mobile
- Jangflix: React Native → Flutter
- Add RNP, DepuisleChamp, Forum Mondial de l'Eau, OIF x Gebeya, IPRES, TekkiFi

## Summary by Sourcery

Update portfolio project listings and technology stacks in localized message files.

New Features:
- Add new portfolio projects (RNP, DepuisleChamp, Forum Mondial de l'Eau, OIF x Gebeya, IPRES, TekkiFi) to the portfolio content.

Enhancements:
- Update Sembass/Jengu stack from React web to Flutter mobile in portfolio metadata.
- Update Jangflix stack from React Native to Flutter in portfolio metadata.

Documentation:
- Refresh English and French portfolio copy to reflect the new and updated projects.